### PR TITLE
CA-173690: Guest Agent: /usr/sbin/xe-linux-distribution cannot works …

### DIFF
--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -266,8 +266,8 @@ identify_lsb()
     fi
 
     eval $(echo $release | awk -F. -- '{ subindex = index($0,"."); \
-                                         print "major=" $1 ; \
-                                         print "minor=" substr($0,subindex+1) }')
+                                         print "major=\"" $1 "\""; \
+                                         print "minor=\"" substr($0,subindex+1) "\"" }')
 
     if [ -z "${major}" -o -z "${distro}" ] ; then
         return 1


### PR DESCRIPTION
…in latest boot2docker.

latest Boot2Docker lsb_relase output
```
	Boot2Docker 1.6.2 (TCL 6.3); master : 68777f2
```
/usr/sbin/xe-linux-distribution cannot handle "(TCL 6.3)" string

This commit is to fix this issue.