### PR TITLE
Make xe-daemon generate less xenstore traffic

### DIFF
--- a/xenstoreclient/xenstore.go
+++ b/xenstoreclient/xenstore.go
@@ -374,7 +374,7 @@ func (xs *CachedXenStore) Write(path string, value string) error {
 		}
 	}
 	err := xs.xs.Write(path, value)
-	if err != nil {
+	if err == nil {
 		xs.writeCache[path] = value
 		xs.lastCommit[path] = time.Now()
 	}


### PR DESCRIPTION
The first commit is an attempted bug-fix. Please review that this now restores the intended behaviour of the write-cache.

The second commit is a proposed optimisation. I personally don't see the need for the 2-minute timeout for the cache. But perhaps I am missing something, so please correct me if there's a reason we need this.