### PR TITLE
CA-220438: Minor improvements for xe-guest-utilities

### DIFF
--- a/mk/Makefile.deb
+++ b/mk/Makefile.deb
@@ -115,7 +115,8 @@ $(MY_OUTPUT_DIR)/xe-guest-utilities.%.inc: $(MY_OUTPUT_DIR)/.dirstamp
 	( echo XE_GUEST_UTILITIES_PKG_NAME := xe-guest-utilities ; \
 	  echo XE_GUEST_UTILITIES_PKG_VERSION := $(VERSION)-$(RELEASE) ; \
 	  echo XE_GUEST_UTILITIES_PKG_ARCH := $* ; \
-	  echo XE_GUEST_UTILITIES_PKG_FILE := $(DEBPOOLDIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_all.deb ; \
+	  echo XE_GUEST_UTILITIES_PKG_FILE_i386 := $(DEBPOOLDIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_i386.deb ; \
+	  echo XE_GUEST_UTILITIES_PKG_FILE_amd64 := $(DEBPOOLDIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_amd64.deb ; \
 	)>$@
 
 $(DEB_BUILT_COOKIE): $(SOURCES)	
@@ -126,7 +127,7 @@ $(DEB_BUILT_COOKIE): $(SOURCES)
 	cp $(MY_OBJ_DIR)/$(PACKAGE)_$(VERSION)-$(RELEASE).tar.gz $(MY_OUTPUT_DIR)/$(DEBPOOLDIR)
 	set -xe ; for arch in $(ARCHS) ; do \
 		( cd $(SOURCEDIR) && dpkg-buildpackage -Zgzip -b -a$${arch} -us -uc ) ; \
-		cp $(MY_OBJ_DIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_all.deb $(MY_OUTPUT_DIR)/$(DEBPOOLDIR) ; \
+		cp $(MY_OBJ_DIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_$${arch}.deb $(MY_OUTPUT_DIR)/$(DEBPOOLDIR) ; \
 	done
 	touch $@
 
@@ -163,7 +164,7 @@ $(TOOLS_TARBALL): $(DEB_BUILT_COOKIE)
 	mkdir -p $(INSTALL_DIR)
 	rm -f $(INSTALL_DIR)/versions.deb
 	$(foreach arch,$(ARCHS),\
-	  echo XE_GUEST_UTILITIES_PKG_FILE_$(arch)=\'xe-guest-utilities_$(VERSION)-$(RELEASE)_all.deb\' >> $(INSTALL_DIR)/versions.deb ; cp -v $(MY_OBJ_DIR)/xe-guest-utilities_$(VERSION)-$(RELEASE)_all.deb $(INSTALL_DIR)/ ;)
+	  echo XE_GUEST_UTILITIES_PKG_FILE_$(arch)=\'xe-guest-utilities_$(VERSION)-$(RELEASE)_$(arch).deb\' >> $(INSTALL_DIR)/versions.deb ; cp -v $(MY_OBJ_DIR)/xe-guest-utilities_$(VERSION)-$(RELEASE)_$(arch).deb $(INSTALL_DIR)/ ;)
 	tar -C $(STAGING_DIR) -cjf $@ .
 
 $(GOROOT):

--- a/mk/Makefile.deb
+++ b/mk/Makefile.deb
@@ -31,7 +31,7 @@ DEBPOOLDIR := debian/pool/main/x/xe-guest-utilities
 GOTARBALL = /distfiles/golang/go1.4.2.linux-386.tar.gz
 GOROOT = $(MY_OBJ_DIR)/go
 GOBIN = GOROOT=$(GOROOT) $(GOROOT)/bin/go
-GOFLAGS = -v
+GOFLAGS = -v -ldflags="-s -w"
 GOBUILDDIR = $(MY_OBJ_DIR)/gobuild
 GO_SOURCE_REPO = $(call git_loc,xe-guest-utilities)
 

--- a/mk/Makefile.rpm
+++ b/mk/Makefile.rpm
@@ -27,7 +27,7 @@ SRPM= xe-guest-utilities-$(VERSION)-$(RELEASE).src.rpm
 GOTARBALL = /distfiles/golang/go1.4.2.linux-386.tar.gz
 GOROOT = $(MY_OBJ_DIR)/go
 GOBIN = GOROOT=$(GOROOT) $(GOROOT)/bin/go
-GOFLAGS = -a -x
+GOFLAGS = -a -x -ldflags="-s -w"
 GOBUILDDIR = $(MY_OBJ_DIR)/gobuild
 
 GO_SOURCE_REPO = $(call git_loc,xe-guest-utilities)

--- a/mk/Makefile.tgz
+++ b/mk/Makefile.tgz
@@ -30,7 +30,7 @@ DESTDIR := $(MY_OBJ_DIR)/$(PACKAGE)/
 GOTARBALL = /distfiles/golang/go1.4.2.linux-386.tar.gz
 GOROOT = $(MY_OBJ_DIR)/go
 GOBIN = GOROOT=$(GOROOT) $(GOROOT)/bin/go
-GOFLAGS = -v
+GOFLAGS = -v -ldflags="-s -w"
 GOBUILDDIR = $(MY_OBJ_DIR)/gobuild
 
 GO_SOURCE_REPO = $(call git_loc,xe-guest-utilities)

--- a/mk/Makefile.tgz
+++ b/mk/Makefile.tgz
@@ -116,7 +116,7 @@ $(TGZ_BUILT_COOKIE): $(SOURCES)
 	  install -d $(DESTDIR)/usr/share/doc/$(PACKAGE)_$(VERSION)/ ; \
 	  install -m 644 $(REPO)/LICENSE $(DESTDIR)/usr/share/doc/$(PACKAGE)_$(VERSION)/LICENSE ; \
 	  cd $(DESTDIR) ; \
-	  tar cvf $(MY_OBJ_DIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_all.tgz * \
+	  tar czvf $(MY_OBJ_DIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_all.tgz * \
 	)>$@
 
 $(MY_SOURCES)/MANIFEST: $(MY_SOURCES_DIRSTAMP)

--- a/mk/debian/control
+++ b/mk/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.7.2
 Build-Depends: debhelper (>= 4.0.0)
 
 Package: xe-guest-utilities
-Architecture: all
+Architecture: any
 Conflicts: xengmond
 Replaces: xengmond
 Description: @BRAND_GUEST@ Monitoring Scripts

--- a/mk/xe-linux-distribution.init
+++ b/mk/xe-linux-distribution.init
@@ -80,7 +80,10 @@ start()
 
 stop()
 {
+    [ ! -f "${XE_DAEMON_PIDFILE}" ] && return 0
     action $"Stopping xe daemon: "   kill -TERM $(cat ${XE_DAEMON_PIDFILE})
+    rm -f "${XE_DAEMON_PIDFILE}"
+    return 0
 }
 
 status()

--- a/xe-daemon/xe-daemon.go
+++ b/xe-daemon/xe-daemon.go
@@ -105,7 +105,9 @@ func main() {
 		updated := false
 		for _, collector := range collectors {
 			if count%collector.divisor == 0 {
-				logger.Printf("Running %s ...\n", collector.name)
+				if *debugFlag {
+					logger.Printf("Running %s ...\n", collector.name)
+				}
 				result, err := collector.Collect()
 				if err != nil {
 					logger.Printf("%s error: %#v\n", collector.name, err)


### PR DESCRIPTION
1. Package architecture-specific binaries for debian
2. Mute xe-daemon logs unless debug flag is set
3. Correct tgz packaging
3. Let xe-linux-distribution handle its PID file safely

Signed-off-by: Phus Lu <phus.lu@citrix.com>