### PR TITLE
CP-20237: Replace place-holder for DISTRO to '^'

### DIFF
--- a/mk/Citrix.repo
+++ b/mk/Citrix.repo
@@ -1,7 +1,7 @@
 [citrix]
-name=@PRODUCT_BRAND@ @PRODUCT_VERSION@ updates for @DISTRO@
-mirrorlist=http://updates.vmd.citrix.com/@PRODUCT_BRAND@/@PRODUCT_VERSION@/@DISTRO@/mirrorlist
-#baseurl=http://updates.vmd.citrix.com/@PRODUCT_BRAND@/@PRODUCT_VERSION@/@DISTRO@/
+name=@PRODUCT_BRAND@ @PRODUCT_VERSION@ updates for ^DISTRO^
+mirrorlist=http://updates.vmd.citrix.com/@PRODUCT_BRAND@/@PRODUCT_VERSION@/^DISTRO^/mirrorlist
+#baseurl=http://updates.vmd.citrix.com/@PRODUCT_BRAND@/@PRODUCT_VERSION@/^DISTRO^/
 gpgcheck=1
 gpgkey=http://updates.vmd.citrix.com/@PRODUCT_BRAND@/RPM-GPG-KEY-@PRODUCT_VERSION@
 enabled=1

--- a/mk/citrix.list
+++ b/mk/citrix.list
@@ -1,2 +1,2 @@
-deb     http://updates.vmd.citrix.com/@PRODUCT_BRAND@/@PRODUCT_VERSION@/debian/ @DISTRO@ main
-deb-src http://updates.vmd.citrix.com/@PRODUCT_BRAND@/@PRODUCT_VERSION@/debian/ @DISTRO@ main
+deb     http://updates.vmd.citrix.com/@PRODUCT_BRAND@/@PRODUCT_VERSION@/debian/ ^DISTRO^ main
+deb-src http://updates.vmd.citrix.com/@PRODUCT_BRAND@/@PRODUCT_VERSION@/debian/ ^DISTRO^ main

--- a/mk/debian/xe-guest-utilities.postinst
+++ b/mk/debian/xe-guest-utilities.postinst
@@ -12,7 +12,7 @@ if [ X"$1" = X"configure" ] ; then
 	esac
 	if [ -n "${distro}" ] ; then
             rm -f /etc/apt/sources.list.d/xensource.list # contains deprecated urls
-	    sed -e "s/@DISTRO@/${distro}/g" \
+	    sed -e "s/\^DISTRO\^/${distro}/g" \
 		< /usr/share/xe-guest-utilities/citrix.list \
 		> /etc/apt/sources.list.d/citrix.list
 	fi

--- a/mk/xe-guest-utilities.spec.in
+++ b/mk/xe-guest-utilities.spec.in
@@ -84,7 +84,7 @@ if [ -d /etc/yum.repos.d ] && [ -n "${os_distro}" ] && [ -n "${os_majorver}" ] ;
         if [ -f /etc/yum.repos.d/XenSource.repo ] ; then
             rm -f /etc/yum.repos.d/XenSource.repo # contains deprecated urls
         fi
-        sed -e "s/@DISTRO@/${distro}/g" \
+        sed -e "s/\^DISTRO\^/${distro}/g" \
             < /usr/share/doc/%{name}-%{version}/examples/Citrix.repo \
             > /etc/yum.repos.d/Citrix.repo
         ;;


### PR DESCRIPTION
Signed-off-by: Kun Ma <kun.ma@citrix.com>

Since we want to use branding-xenserver to brand all files. And those post process string(DISTRO) should be distinguish with the branded file. So replace '@' with '^'.