### PR TITLE
CA-261230: add support NeoKylin 5.0 for alternative version

### DIFF
--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -287,6 +287,7 @@ identify_kylin()
 
     # distro
     # NeoKylin Linux Security OS V5.0 (Update8)
+    # Neokylin Linux Security OS Server release V5 (Santiago)
     # NeoKylin Linux Advanced Server release 6.5 (Berryllium)
     # NeoKylin Linux Advanced Server release 7.0
 
@@ -295,7 +296,7 @@ identify_kylin()
     fi
 
     eval $(sed -rn \
-            's/^NeoKylin Linux.*([0-9]+)\.([0-9]+).*$/distro=neokylin;major=\1;minor=\2;/gp;' \
+            's/^Neo[kK]ylin Linux[^0-9]+([0-9]+)\.?([0-9]+)?.*$/distro=neokylin;major=\1;minor=\2;/gp;' \
             "${kylin_release}")
 
     if [ -z "${major}" -o -z "${distro}" ] ; then


### PR DESCRIPTION
Signed-off-by: Deli Zhang <Deli.Zhang@citrix.com>

Tested by hand, the new RE works:
\# echo 'NeoKylin Linux Security OS V5.0 (Update8)' | sed -rn 's/^Neo[kK]ylin Linux [^0-9]+([0-9]+)\.?([0-9]+)?.*$/distro=neokylin;major=\1;minor=\2;/gp;'
distro=neokylin;major=5;minor=0;

\# echo 'Neokylin Linux Security OS Server release V5 (Santiago)' | sed -rn 's/^Neo[kK]ylin Linux [^0-9]+([0-9]+)\.?([0-9]+)?.*$/distro=neokylin;major=\1;minor=\2;/gp;'
distro=neokylin;major=5;minor=;

\# echo 'NeoKylin Linux Advanced Server release 6.5 (Berryllium)' | sed -rn 's/^Neo[kK]ylin Linux [^0-9]+([0-9]+)\.?([0-9]+)?.*$/distro=neokylin;major=\1;minor=\2;/gp;'
distro=neokylin;major=6;minor=5;

\# echo 'NeoKylin Linux Advanced Server release 7.0' | sed -rn 's/^Neo[kK]ylin Linux [^0-9]+([0-9]+)\.?([0-9]+)?.*$/distro=neokylin;major=\1;minor=\2;/gp;'
distro=neokylin;major=7;minor=0;
