### PR TITLE
Properly compress the generated tgz file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(DISTDIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_$(ARCH).tgz: $(OBJECTS)
 	  install -d $(STAGEDIR)/etc/udev/rules.d/ ; \
 	  install -m 644 $(SOURCEDIR)/xen-vcpu-hotplug.rules $(STAGEDIR)/etc/udev/rules.d/z10_xen-vcpu-hotplug.rules ; \
 	  cd $(STAGEDIR) ; \
-	  tar cf $@ * \
+	  tar zcf $@ * \
 	)
 
 $(OBJECTDIR)/xe-daemon: $(XE_DAEMON_SOURCES:%=$(GOBUILDDIR)/%)


### PR DESCRIPTION
The file has a '.tgz' suffix, but was not actually compressed.

Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>