### PR TITLE
Make xenstore utilities link to relative path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,11 @@ $(DISTDIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_$(ARCH).tgz: $(OBJECTS)
 	  install -m 755 $(OBJECTDIR)/xe-daemon $(STAGEDIR)/usr/sbin/xe-daemon ; \
 	  install -d $(STAGEDIR)/usr/bin/ ; \
 	  install -m 755 $(OBJECTDIR)/xenstore $(STAGEDIR)/usr/bin/xenstore ; \
-	  ln -sf /usr/bin/xenstore $(STAGEDIR)/usr/bin/xenstore-read ; \
-	  ln -sf /usr/bin/xenstore $(STAGEDIR)/usr/bin/xenstore-write ; \
-	  ln -sf /usr/bin/xenstore $(STAGEDIR)/usr/bin/xenstore-exists ; \
-	  ln -sf /usr/bin/xenstore $(STAGEDIR)/usr/bin/xenstore-rm ; \
-	  ln -sf /usr/bin/xenstore $(STAGEDIR)/usr/bin/xenstore-list ; \
+	  ln -sf xenstore $(STAGEDIR)/usr/bin/xenstore-read ; \
+	  ln -sf xenstore $(STAGEDIR)/usr/bin/xenstore-write ; \
+	  ln -sf xenstore $(STAGEDIR)/usr/bin/xenstore-exists ; \
+	  ln -sf xenstore $(STAGEDIR)/usr/bin/xenstore-rm ; \
+	  ln -sf xenstore $(STAGEDIR)/usr/bin/xenstore-list ; \
 	  install -d $(STAGEDIR)/etc/udev/rules.d/ ; \
 	  install -m 644 $(SOURCEDIR)/xen-vcpu-hotplug.rules $(STAGEDIR)/etc/udev/rules.d/z10_xen-vcpu-hotplug.rules ; \
 	  cd $(STAGEDIR) ; \


### PR DESCRIPTION
Relative path linking makes the group of xenstore utilities
more portable.