### PR TITLE
fix missing cmd in deb package

### DIFF
--- a/mk/debian/rules
+++ b/mk/debian/rules
@@ -30,6 +30,8 @@ binary-arch: build
 	ln -s /usr/bin/xenstore $(DESTDIR)/usr/bin/xenstore-write
 	ln -s /usr/bin/xenstore $(DESTDIR)/usr/bin/xenstore-exists
 	ln -s /usr/bin/xenstore $(DESTDIR)/usr/bin/xenstore-rm
+	ln -s /usr/bin/xenstore $(DESTDIR)/usr/bin/xenstore-list
+	ln -s /usr/bin/xenstore $(DESTDIR)/usr/bin/xenstore-ls
 
 	cp xe-daemon $(DESTDIR)/usr/sbin/xe-daemon
 	chmod 0755 $(DESTDIR)/usr/sbin/xe-daemon


### PR DESCRIPTION
xe-guest-utilities.spec.in is not used in our build process.

Signed-off-by: Talons Lee <xin.li@citrix.com>