### PR TITLE
Update xe-linux-distribution

### DIFF
--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -148,6 +148,7 @@ identify_redhat()
                -e 's/^CentOS release \([0-9]*\)\.\([0-9]*\) (.*)/distro=centos;major=\1;minor=\2/gp;' \
                -e 's/^CentOS release \([0-9]*\) (.*)/distro=centos;major=\1/gp;' \
                -e 's/^CentOS Linux release \([0-9]*\)\.\([0-9]*\)\(\.[0-9]*\)\? (.*)/distro=centos;major=\1;minor=\2/gp;' \
+	       -e 's/^CloudLinux Linux release \([0-9]*\)\.\([0-9]*\)\(\.[0-9]*\)\? (.*)/distro=cloudlinux;major=\1;minor=\2/gp;' \
                -e 's/^Enterprise Linux Enterprise Linux .* release \([0-9]*\)\.\([0-9]*\) (.*)$/distro=oracle;major=\1;minor=\2;/gp;' \
                -e 's/^Enterprise Linux Enterprise Linux .* release \([0-9]*\) (.*)$/distro=oracle;major=\1/gp;' \
                -e 's/^Oracle Linux Server release \([0-9]*\)\.\([0-9]*\)$/distro=oracle;major=\1;minor=\2/gp;' \


### PR DESCRIPTION
The CloudLinux OS, which is based on CentOS, isn't detected properly by the xentools. This adjustment allows it to be.