### PR TITLE
CA-333687: Fix boot hang caused by CPU hotplug rule

### DIFF
--- a/mk/xen-vcpu-hotplug.rules
+++ b/mk/xen-vcpu-hotplug.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="cpu", RUN+="/bin/sh -c '( ! /usr/bin/xenstore-exists unique-domain-id 2>/dev/null ) || [ ! -e /sys$devpath/online ] || echo 1 > /sys$devpath/online'"
+ACTION=="add", SUBSYSTEM=="cpu", RUN+="/bin/sh -c '[ -e /dev/xen/xenbus ] && [ -e /sys$devpath/online ] && echo 1 > /sys$devpath/online'"


### PR DESCRIPTION
The guest agent installs a udev rule which triggers when a CPU is added.
The rule checks whether it is running under Xen using xenstore-exists,
and then onlines the vCPU.

This is problematic during boot because xenstore-exists tries to connect
to xenstore by accessing /proc/xen/xenbus which is on a separate mount
that either doesn't exist at that point or isn't usable. The result is a
hang and systemd-udev-settle.service stalling boot.

Fix it by simply checking for the presence of /dev/xen/xenbus to
determine whether the agent is running under Xen.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>