### PR TITLE
CA-349929: Fix handling of /etc/centos-release for CentOS 8.3+

### DIFF
--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -147,7 +147,7 @@ identify_redhat()
                -e 's/^Fedora.*release \([0-9]*\) (.*)$/distro=fedora;major=\1/gp;' \
                -e 's/^CentOS release \([0-9]*\)\.\([0-9]*\) (.*)/distro=centos;major=\1;minor=\2/gp;' \
                -e 's/^CentOS release \([0-9]*\) (.*)/distro=centos;major=\1/gp;' \
-               -e 's/^CentOS Linux release \([0-9]*\)\.\([0-9]*\)\(\.[0-9]*\)\? (.*)/distro=centos;major=\1;minor=\2/gp;' \
+               -e 's/^CentOS Linux release \([0-9]*\)\.\([0-9]*\).*$/distro=centos;major=\1;minor=\2/gp;' \
                -e 's/^Enterprise Linux Enterprise Linux .* release \([0-9]*\)\.\([0-9]*\) (.*)$/distro=oracle;major=\1;minor=\2;/gp;' \
                -e 's/^Enterprise Linux Enterprise Linux .* release \([0-9]*\) (.*)$/distro=oracle;major=\1/gp;' \
                -e 's/^Oracle Linux Server release \([0-9]*\)\.\([0-9]*\)$/distro=oracle;major=\1;minor=\2/gp;' \


### PR DESCRIPTION
The format of /etc/centos-release has changed to not include any additional
content after the version number, which was not being matched by our existing
regular expression. Update the expression so it works with both the original
(e.g. CentOS 7 format), and the newer format.

Signed-off-by: Alex Brett <alex.brett@citrix.com>