### PR TITLE
Fix name of tarball based on GOARCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ OBJECTS += $(OBJECTDIR)/xenstore
 PACKAGE = xe-guest-utilities
 VERSION = $(PRODUCT_VERSION)
 RELEASE := $(shell git rev-list HEAD | wc -l)
-ARCH := $(shell go version|awk -F'/' '{print $$2}')
+ifeq ($(GOARCH),)
+        ARCH := $(shell go version|awk -F'/' '{print $$2}')
+else
+        ARCH := $(GOARCH)
+endif
 
 ifeq ($(ARCH), amd64)
 	ARCH = x86_64


### PR DESCRIPTION
If the GOARCH environment variable is defined, use it as the arch
for the name of the tarball produced in build/dist/

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>

Without this, `GOARCH=386 make` produces a tarball that contains `x86_64` in the filename.