### PR TITLE
Update for building with go 1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,16 @@ ifeq ($(ARCH), amd64)
 endif
 
 XE_DAEMON_SOURCES :=
-XE_DAEMON_SOURCES += ./xe-daemon/xe-daemon.go
-XE_DAEMON_SOURCES += ./syslog/syslog.go
-XE_DAEMON_SOURCES += ./system/system.go
-XE_DAEMON_SOURCES += ./guestmetric/guestmetric.go
-XE_DAEMON_SOURCES += ./guestmetric/guestmetric_linux.go
-XE_DAEMON_SOURCES += ./xenstoreclient/xenstore.go
+XE_DAEMON_SOURCES += xe-daemon/xe-daemon.go
+XE_DAEMON_SOURCES += syslog/syslog.go
+XE_DAEMON_SOURCES += system/system.go
+XE_DAEMON_SOURCES += guestmetric/guestmetric.go
+XE_DAEMON_SOURCES += guestmetric/guestmetric_linux.go
+XE_DAEMON_SOURCES += xenstoreclient/xenstore.go
 
 XENSTORE_SOURCES :=
-XENSTORE_SOURCES += ./xenstore/xenstore.go
-XENSTORE_SOURCES += ./xenstoreclient/xenstore.go
+XENSTORE_SOURCES += xenstore/xenstore.go
+XENSTORE_SOURCES += xenstoreclient/xenstore.go
 
 .PHONY: build
 build: $(DISTDIR)/$(PACKAGE)_$(VERSION)-$(RELEASE)_$(ARCH).tgz

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module xe-guest-utilities
+
+go 1.16
+
+require golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0 h1:g9s1Ppvvun/fI+BptTMj909BBIcGrzQ32k9FNlcevOE=
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/guestmetric/guestmetric_linux.go
+++ b/guestmetric/guestmetric_linux.go
@@ -1,7 +1,6 @@
 package guestmetric
 
 import (
-	xenstoreclient "../xenstoreclient"
 	"bufio"
 	"bytes"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	xenstoreclient "xe-guest-utilities/xenstoreclient"
 )
 
 type Collector struct {

--- a/xe-daemon/xe-daemon.go
+++ b/xe-daemon/xe-daemon.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	guestmetric "../guestmetric"
-	syslog "../syslog"
-	system "../system"
-	xenstoreclient "../xenstoreclient"
 	"flag"
 	"fmt"
 	"io"
@@ -15,6 +11,10 @@ import (
 	"strconv"
 	"syscall"
 	"time"
+	guestmetric "xe-guest-utilities/guestmetric"
+	syslog "xe-guest-utilities/syslog"
+	system "xe-guest-utilities/system"
+	xenstoreclient "xe-guest-utilities/xenstoreclient"
 )
 
 const (

--- a/xenstore/xenstore.go
+++ b/xenstore/xenstore.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	xenstoreclient "../xenstoreclient"
 	"errors"
 	"fmt"
 	"golang.org/x/sys/unix"
 	"os"
 	"strconv"
 	"strings"
+	xenstoreclient "xe-guest-utilities/xenstoreclient"
 )
 
 func die(format string, a ...interface{}) {


### PR DESCRIPTION
Due to changes in the module system, go 1.16 no longer tolerates including
local folders via
	import "../system"
Now, on is expected to reference the name of the parent project
	import "xe-guest-utilities/system"

Additional go now expects a go.mod file with listing of external dependencies
and a go.sum with hashes of those.

And go no longer allows '.' within paths that aren't URLs.