### PR TITLE
Fix archlinux guestmetric for ip interfaces

### DIFF
--- a/guestmetric/guestmetric_linux.go
+++ b/guestmetric/guestmetric_linux.go
@@ -182,7 +182,7 @@ func (c *Collector) CollectNetworkAddr() (GuestMetric, error) {
 	current := make(GuestMetric, 0)
 
 	var paths []string
-	vifNamePrefixList := [...]string{"eth", "eno", "ens", "emp", "enx"}
+	vifNamePrefixList := [...]string{"eth", "eno", "ens", "emp", "enx", "enX"}
 	for _, prefix := range vifNamePrefixList {
 		prefixPaths, err := filepath.Glob(fmt.Sprintf("/sys/class/net/%s*", prefix))
 		if err != nil {


### PR DESCRIPTION
When you launch an Arch VM on xcp-ng, you have an interface where the name starts with enX, not enx, which means that the main interface is not found.

![Screenshot_20220128_191308](https://user-images.githubusercontent.com/7694420/151571923-90db5215-f550-45ac-9383-0f297196a840.png)
