### PR TITLE
Fix identification of blockdev block size

### DIFF
--- a/guestmetric/guestmetric_linux.go
+++ b/guestmetric/guestmetric_linux.go
@@ -250,7 +250,7 @@ func (c *Collector) CollectDisk() (GuestMetric, error) {
 				return nil, err
 			}
 			blocksize := 512
-			if bs, err := readSysfs(fmt.Sprintf("/sys/block/%s/queue/physical_block_size", p)); err == nil {
+			if bs, err := readSysfs(fmt.Sprintf("/sys/block/%s/queue/physical_block_size", disk)); err == nil {
 				if bs1, err := strconv.Atoi(bs); err == nil {
 					blocksize = bs1
 				}


### PR DESCRIPTION
Noticed this small issue when reading the code - don't have hardware to test it, but it seems pretty straighforward