### PR TITLE
Release/yangtze/lcm

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) Cloud Software Group Holdings, Inc.
+Copyright (C) Citrix Systems, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Introduction
 
-This is the golang guest utilities for XenServer
+This is the golang guest utilities for Citrix Hypervisor
 
 
 XenStore golang client library

--- a/mk/debian/control
+++ b/mk/debian/control
@@ -1,7 +1,7 @@
 Source: xe-guest-utilities
 Section: main/admin
 Priority: optional
-Maintainer: Cloud Software Group Holdings, Inc.
+Maintainer: Citrix Systems, Inc. <www.citrix.com>
 Standards-Version: 3.7.2
 Build-Depends: debhelper (>= 4.0.0)
 

--- a/mk/xe-linux-distribution
+++ b/mk/xe-linux-distribution
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-# Copyright (c) 2022, Cloud Software Group Holdings, Inc.
+# Copyright (c) 2015, Citrix Systems
 # All rights reserved.
 
 # Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
CP-42908: Backport Linux Guest Tools from Next to Yangtze 
    - exclude some rebranding commit. 
    - create a new branch release/yangtze/lcm for Yangtze updates

Signed-off-by: Lunfan Zhang <Lunfan.Zhang@citrix.com>