### PR TITLE
CA-382285 Extract Memory Information From MemFree When Kernel Version…

### DIFF
--- a/guestmetric/guestmetric_linux.go
+++ b/guestmetric/guestmetric_linux.go
@@ -63,12 +63,18 @@ func (c *Collector) CollectMemory() (GuestMetric, error) {
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
+	foundMemAvailabel := false
 	for scanner.Scan() {
 		parts := regexp.MustCompile(`\w+`).FindAllString(scanner.Text(), -1)
 		switch parts[0] {
 		case "MemTotal":
 			current["meminfo_total"] = parts[1]
+		case "MemFree":
+			if !foundMemAvailabel{
+				current["meminfo_free"] = parts[1]
+			} 
 		case "MemAvailable":
+			foundMemAvailabel = true
 			current["meminfo_free"] = parts[1]
 		}
 	}


### PR DESCRIPTION
For current implementation, some guests do not report meminfo_free information.
this is because the guest tool only use **MemAvailable** to obtain memory free information. assuming that all guests will respond with the **MemAvailable** parameter. However, the fact is that kernels earlier than 3.14 do not provide **MemAvailable** . Therefore, for guest which still use the ancient version of kernel (e.g. RHEL6), it is better to match **MemFree** instead to obtain memory free information.

3.14 Kernel commit: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0a

before refine:
```
# xenstore-ls| grep mem
memory = ""
 memory-offset = "69696"
 meminfo_total = "4038196"
```

Afte refine:
```
# xenstore-ls| grep mem
memory = ""
 memory-offset = "69696"
 meminfo_total = "4038196"
 meminfo_free = "3487488"
```