### PR TITLE
CP-49568 Guest agent fails to collect disk metrics when PV is not associated with a VG

### DIFF
--- a/guestmetric/guestmetric_linux.go
+++ b/guestmetric/guestmetric_linux.go
@@ -290,11 +290,12 @@ func (c *Collector) CollectDisk() (GuestMetric, error) {
 				"name":      name,
 				"size":      strconv.FormatInt(size*int64(blocksize), 10),
 			}
-			output, err := runCmd("pvs", "--noheadings", "--units", "b", path)
+			output, err := runCmd("pvs", "--noheadings", "--units", "b", "-o", "pv_free,pv_fmt", path)
 			if err == nil && output != "" {
+				//exclude the first blank element
 				parts := regexp.MustCompile(`\s+`).Split(output, -1)[1:]
-				i["free"] = strings.TrimSpace(parts[5])[:len(parts[5])-1]
-				i["filesystem"] = strings.TrimSpace(parts[2])
+				i["free"] = strings.TrimSpace(parts[0])[:len(parts[0])-1]
+				i["filesystem"] = strings.TrimSpace(parts[1])
 				i["mount_points/0"] = "[LVM]"
 			} else {
 				output, err = runCmd("mount")


### PR DESCRIPTION
In certain cases, if a physical volume (PV) is created but not associated with a volume group (VG), the output of `output, err := runCmd("pvs", "--noheadings", "--units", "b", path)` will be:

`/dev/xvda1 lvm2 a-- 2097664B 2097664B`
This output structure can lead to an out-of-bounds error when attempting to access the free space of the PV via parts[5], and guest agent will crash.

This PR ensures accurate retrieval of PV free space and filesystem information using the --options parameter, preventing potential index mismatch errors.