### PR TITLE
CP-53590 IP Address Metrics Not Reported Immediately After Reboot

### DIFF
--- a/mk/xe-linux-distribution.service
+++ b/mk/xe-linux-distribution.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Linux Guest Agent
 ConditionVirtualization=xen
+After=network-online.target
+wants=network-online.target
 
 [Service]
 ExecStartPre=/usr/share/oem/xs/xe-linux-distribution /var/cache/xe-linux-distribution


### PR DESCRIPTION
Add a service dependency on the network-online target to ensure the guest agent service starts after the network is online and collects network metrics during the first loop.