### PR TITLE
CA-337100: fix xenstore-ls panic on deeply nested trees

### DIFF
--- a/xenstore/xenstore.go
+++ b/xenstore/xenstore.go
@@ -173,7 +173,10 @@ func do_xs_ls(xs xenstoreclient.XenStoreClient, path string, depth int) {
 		if n > (max_width - len(TAG) - col) {
 			n = (max_width - len(TAG) - col)
 		}
-		fmt.Printf(sub_path[:n])
+		if n < 0 {
+			n = 0
+		}
+		fmt.Print(sub_path[:n])
 		col += n
 
 		if len(newPath) >= STRING_MAX {


### PR DESCRIPTION
when a node's indentation depth passed the budget, **N** went to the negative which will raise  runtime error: `slice bounds out of range [:-1]`. this fix add a check so when the indent already exceeds the width budget, the name simply prints as empty `(sub_path[:0])` rather than panicking.